### PR TITLE
chore(useRedux): remove unnecessary function creation.

### DIFF
--- a/src/useRedux.js
+++ b/src/useRedux.js
@@ -6,10 +6,10 @@ export const useRedux = (selectors, actionCreators) => {
   const { getState, dispatch, subscribe } = store;
   const [reduxState, setReduxState] = useState(getState());
 
-  useEffect(() => {
-    const unsubscribe = subscribe(() => setReduxState(getState()));
-    return () => unsubscribe();
-  }, []);
+  useEffect(
+    () => subscribe(() => setReduxState(getState())),
+    []
+  );
 
   let values;
   let actions;

--- a/src/useRedux.js
+++ b/src/useRedux.js
@@ -6,10 +6,7 @@ export const useRedux = (selectors, actionCreators) => {
   const { getState, dispatch, subscribe } = store;
   const [reduxState, setReduxState] = useState(getState());
 
-  useEffect(
-    () => subscribe(() => setReduxState(getState())),
-    []
-  );
+  useEffect(() => subscribe(() => setReduxState(getState())), []);
 
   let values;
   let actions;


### PR DESCRIPTION
We don't need to create an extra function to return. The result of the `subscribe` call can be returned directly.