### PR TITLE
feat(actionCreators): allow useActionCreators functions to have more than one param

### DIFF
--- a/src/__tests__/useActionCreators.spec.js
+++ b/src/__tests__/useActionCreators.spec.js
@@ -17,6 +17,7 @@ describe('useActionCreators', () => {
 
   const a1Creator = () => ({ type: 'FOO' });
   const a2Creator = payload => ({ type: 'BAR', payload });
+  const a3Creator = (name, id) => ({ type: 'NAMEID', name, id });
 
   it('should return actions', () => {
     const actions = useActionCreators(a1Creator, a2Creator);
@@ -31,5 +32,14 @@ describe('useActionCreators', () => {
 
     a2('payload');
     expect(dispatch).toHaveBeenCalledWith({ type: 'BAR', payload: 'payload' });
+  });
+
+  it('shoud allow action creators with more than one parameter', () => {
+    const actions = useActionCreators(a3Creator);
+
+    const [a3] = actions;
+
+    a3('skywalker', 1);
+    expect(dispatch).toHaveBeenCalledWith({ type: 'NAMEID', name: 'skywalker', id: 1 });
   });
 });

--- a/src/useActionCreators.js
+++ b/src/useActionCreators.js
@@ -5,7 +5,7 @@ export const useActionCreators = (...actionCreators) => {
   const { store } = useContext(ReactReduxContext);
   const { dispatch } = store;
 
-  return actionCreators.map(actionCreator => params =>
-    dispatch(actionCreator(params))
+  return actionCreators.map(actionCreator => (...params) =>
+    dispatch(actionCreator(...params))
   );
 };


### PR DESCRIPTION
The way the function was before, if we were to use the following code, it would disregard every parameter except the first one

```javascript
const { thisWorks, thisAlsoWorks, thisIsNotCool } = useActionCreators({
  thisWorks: () => ({ foo: 'bar' }),
  thisAlsoWorks: (foo) => ({ foo }),
  thisIsNotCool: (foo, bar) => ({ foo, bar }), // bar will always be undefined.
});

// dispatches { foo: 'bar' }
thisWorks();

// dispatches { foo: 'bar' }
thisAlsoWorks('bar');

// dispatches { foo: 'bar', bar: undefined }
thisIsNotCool('bar', 'omg');
```

