### PR TITLE
perf(selectors): optimize rerender if selected values are unchanged

### DIFF
--- a/src/__tests__/useActionCreators.spec.js
+++ b/src/__tests__/useActionCreators.spec.js
@@ -40,6 +40,10 @@ describe('useActionCreators', () => {
     const [a3] = actions;
 
     a3('skywalker', 1);
-    expect(dispatch).toHaveBeenCalledWith({ type: 'NAMEID', name: 'skywalker', id: 1 });
+    expect(dispatch).toHaveBeenCalledWith({
+      type: 'NAMEID',
+      name: 'skywalker',
+      id: 1
+    });
   });
 });


### PR DESCRIPTION
Do not `setState` if selected values are unchanged.